### PR TITLE
Reverts Logic to Fetch Data

### DIFF
--- a/DataProcessing/QuiverWallStreetBetsDataDownloader.cs
+++ b/DataProcessing/QuiverWallStreetBetsDataDownloader.cs
@@ -14,7 +14,6 @@
 */
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -42,20 +41,14 @@ namespace QuantConnect.DataProcessing
     {
         public const string VendorName = "quiver";
         public const string VendorDataName = "wallstreetbets";
-        
+
         private readonly string _destinationFolder;
         private readonly string _universeFolder;
         private readonly string _clientKey;
         private readonly string _dataFolder = Globals.DataFolder;
         private readonly bool _canCreateUniverseFiles;
         private readonly int _maxRetries = 5;
-        private static readonly List<char> _defunctDelimiters = new()
-        {
-            '-',
-            '_'
-        };
-        private ConcurrentDictionary<string, ConcurrentQueue<string>> _tempData = new();
-        
+
         private readonly JsonSerializerSettings _jsonSerializerSettings = new()
         {
             DateTimeZoneHandling = DateTimeZoneHandling.Utc
@@ -93,121 +86,56 @@ namespace QuantConnect.DataProcessing
         {
             var stopwatch = Stopwatch.StartNew();
             var today = DateTime.UtcNow.Date;
-
-            var mapFileProvider = new LocalZipMapFileProvider();
-            mapFileProvider.Initialize(new DefaultDataProvider());
+            Log.Trace($"QuiverWallStreetBetsDataDownloader.Run(): Start downloading/processing QuiverQuant WallStreetBets data");
 
             try
             {
-                var companies = GetCompanies().Result.DistinctBy(x => x.Ticker).ToList();
-                var count = companies.Count;
-                var companiesCompleted = 0;
-
-                Log.Trace(
-                    $"QuiverWallStreetBetsDataDownloader.Run(): Start processing {count.ToStringInvariant()} companies");
-
-                var tasks = new List<Task>();
-
-                foreach (var company in companies)
+                var quiverWsbData = HttpRequester($"historical/wallstreetbets").SynchronouslyAwaitTaskResult();
+                if (string.IsNullOrWhiteSpace(quiverWsbData))
                 {
-                    var quiverTicker = company.Ticker;
+                    // We've already logged inside HttpRequester
+                    return false;
+                }
 
-                    if (!TryNormalizeDefunctTicker(quiverTicker, out var ticker))
+                var wsbMentionsByDate = JsonConvert.DeserializeObject<List<RawQuiverWallStreetBets>>(quiverWsbData, _jsonSerializerSettings)?
+                    .OrderBy(x => x.Date.Date).ThenBy(x => x.Ticker).GroupBy(x => x.Date.Date);
+
+                var wsbMentionsByTicker = new Dictionary<string, List<string>>();
+
+                var mapFileProvider = new LocalZipMapFileProvider();
+                mapFileProvider.Initialize(new DefaultDataProvider());
+
+                foreach (var kvp in wsbMentionsByDate)
+                {
+                    var date = kvp.Key;
+                    if (date == today) continue;
+
+                    var universeCsvContents = new List<string>();
+
+                    foreach (var wsbMention in kvp)
                     {
-                        Log.Error(
-                            $"QuiverWallStreetBetsDataDownloader(): Defunct ticker {quiverTicker} is unable to be parsed. Continuing...");
-                        continue;
-                    }
+                        var ticker = wsbMention.Ticker.ToUpperInvariant();
 
-                    // Begin processing ticker with a normalized value
-                    Log.Trace($"QuiverWallStreetBetsDataDownloader.Run(): Processing {ticker}");
-
-                    tasks.Add(
-                        HttpRequester($"historical/{VendorDataName}/{ticker}")
-                            .ContinueWith(
-                                y =>
-                                {
-                                    if (y.IsFaulted)
-                                    {
-                                        Log.Error(
-                                            $"QuiverWallStreetBetsDataDownloader.Run(): Failed to get data for {company}");
-                                        return;
-                                    }
-
-                                    var result = y.Result;
-                                    if (string.IsNullOrEmpty(result))
-                                    {
-                                        // We've already logged inside HttpRequester
-                                        return;
-                                    }
-
-                                    var wallstreetbetsData =
-                                        JsonConvert.DeserializeObject<List<QuiverWallStreetBets>>(result,
-                                            _jsonSerializerSettings);
-                                    var csvContents = new List<string>();
-
-                                    foreach (var wallstreetbetsDataPoint in wallstreetbetsData)
-                                    {
-                                        var dateTime = wallstreetbetsDataPoint.Date;
-                                        var date = $"{dateTime:yyyyMMdd}";
-                                        var mentions = wallstreetbetsDataPoint.Mentions;
-                                        var rank = wallstreetbetsDataPoint.Rank;
-                                        var sentiment = wallstreetbetsDataPoint.Sentiment;
-
-                                        csvContents.Add($"{date},{mentions},{rank},{sentiment}");
-                                        
-                                        if (!_canCreateUniverseFiles)
-                                            continue;
-                                        
-                                        var sid = SecurityIdentifier.GenerateEquity(ticker, Market.USA, true, mapFileProvider, dateTime);
-
-                                        var universeCsvContents = $"{sid},{ticker},{mentions},{rank},{sentiment}";
-
-                                        var queue = _tempData.GetOrAdd(date, new ConcurrentQueue<string>()); 
-                                        queue.Enqueue(universeCsvContents);
-                                    }
-
-                                    if (csvContents.Count != 0)
-                                    {
-                                        SaveContentToFile(_destinationFolder, ticker, csvContents);
-                                    }
-
-                                    var newCompaniesCompleted = Interlocked.Increment(ref companiesCompleted);
-                                    if (newCompaniesCompleted % 100 == 0)
-                                    {
-                                        Log.Trace(
-                                            $"QuiverWallStreetBetsDataDownloader.Run(): {newCompaniesCompleted}/{count} complete");
-                                    }
-                                }
-                            )
-                    );
-
-                    if (tasks.Count == 10)
-                    {
-                        Task.WaitAll(tasks.ToArray());
-
-                        foreach (var kvp in _tempData)
+                        if (!wsbMentionsByTicker.TryGetValue(ticker, out var wsbTickerMentions))
                         {
-                            SaveContentToFile(_universeFolder, kvp.Key, kvp.Value);
+                            wsbMentionsByTicker.Add(ticker, new List<string>());
                         }
 
-                        _tempData.Clear();
-                        tasks.Clear();
-                    }
-                }
+                        wsbMentionsByTicker[ticker].Add($"{date:yyyyMMdd},{wsbMention.Mentions},{wsbMention.Rank},{wsbMention.Sentiment}");
 
-                if (tasks.Count != 0)
-                {
-                    Task.WaitAll(tasks.ToArray());
-                    
-                    foreach (var kvp in _tempData)
+                        if (!_canCreateUniverseFiles) continue;
+
+                        var sid = SecurityIdentifier.GenerateEquity(ticker, Market.USA, true, mapFileProvider, date);
+                        universeCsvContents.Add($"{sid},{ticker},{wsbMention.Mentions},{wsbMention.Rank},{wsbMention.Sentiment}");
+                    }
+
+                    if (_canCreateUniverseFiles && universeCsvContents.Any())
                     {
-                        SaveContentToFile(_universeFolder, kvp.Key, kvp.Value);
+                        SaveContentToFile(_universeFolder, $"{date:yyyyMMdd}", universeCsvContents);
                     }
-
-                    _tempData.Clear();
-                    tasks.Clear();
                 }
+
+                wsbMentionsByTicker.DoForEach(kvp => SaveContentToFile(_destinationFolder, kvp.Key, kvp.Value));
             }
             catch (Exception e)
             {
@@ -217,24 +145,6 @@ namespace QuantConnect.DataProcessing
 
             Log.Trace($"QuiverWallStreetBetsDataDownloader.Run(): Finished in {stopwatch.Elapsed.ToStringInvariant(null)}");
             return true;
-        }
-
-        /// <summary>
-        /// Gets the list of companies
-        /// </summary>
-        /// <returns>List of companies</returns>
-        /// <exception cref="Exception"></exception>
-        private async Task<List<Company>> GetCompanies()
-        {
-            try
-            {
-                var content = await HttpRequester("companies");
-                return JsonConvert.DeserializeObject<List<Company>>(content);
-            }
-            catch (Exception e)
-            {
-                throw new Exception("QuiverDownloader.GetSymbols(): Error parsing companies list", e);
-            }
         }
 
         /// <summary>
@@ -249,42 +159,43 @@ namespace QuantConnect.DataProcessing
             {
                 try
                 {
-                    using (var client = new HttpClient())
+                    using var client = new HttpClient();
+
+                    client.BaseAddress = new Uri("https://api.quiverquant.com/beta/");
+                    client.DefaultRequestHeaders.Clear();
+
+                    // You must supply your API key in the HTTP header,
+                    // otherwise you will receive a 403 Forbidden response
+                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Token", _clientKey);
+
+                    // Responses are in JSON: you need to specify the HTTP header Accept: application/json
+                    client.DefaultRequestHeaders.Accept.Add(
+                        new MediaTypeWithQualityHeaderValue("application/json"));
+
+                    // Makes sure we don't overrun Quiver rate limits accidentally
+                    _indexGate.WaitToProceed();
+
+                    var response = await client.GetAsync(Uri.EscapeUriString(url));
+                    switch (response.StatusCode)
                     {
-                        client.BaseAddress = new Uri("https://api.quiverquant.com/beta/");
-                        client.DefaultRequestHeaders.Clear();
-
-                        // You must supply your API key in the HTTP header,
-                        // otherwise you will receive a 403 Forbidden response
-                        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Token", _clientKey);
-
-                        // Responses are in JSON: you need to specify the HTTP header Accept: application/json
-                        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                        
-                        // Makes sure we don't overrun Quiver rate limits accidentally
-                        _indexGate.WaitToProceed();
-
-                        var response = await client.GetAsync(Uri.EscapeUriString(url));
-                        if (response.StatusCode == HttpStatusCode.NotFound)
-                        {
+                        case HttpStatusCode.NotFound:
                             Log.Error($"QuiverWallStreetBetsDataDownloader.HttpRequester(): Files not found at url: {Uri.EscapeUriString(url)}");
                             response.DisposeSafely();
                             return string.Empty;
-                        }
-
-                        if (response.StatusCode == HttpStatusCode.Unauthorized)
-                        {
-                            var finalRequestUri = response.RequestMessage.RequestUri; // contains the final location after following the redirect.
-                            response = client.GetAsync(finalRequestUri).Result; // Reissue the request. The DefaultRequestHeaders configured on the client will be used, so we don't have to set them again.
-                        }
-
-                        response.EnsureSuccessStatusCode();
-
-                        var result =  await response.Content.ReadAsStringAsync();
-                        response.DisposeSafely();
-
-                        return result;
+                        case HttpStatusCode.Unauthorized:
+                            {
+                                var finalRequestUri = response.RequestMessage.RequestUri; // contains the final location after following the redirect.
+                                response = client.GetAsync(finalRequestUri).Result; // Reissue the request. The DefaultRequestHeaders configured on the client will be used, so we don't have to set them again.
+                                break;
+                            }
                     }
+
+                    response.EnsureSuccessStatusCode();
+
+                    var result = await response.Content.ReadAsStringAsync();
+                    response.DisposeSafely();
+
+                    return result;
                 }
                 catch (Exception e)
                 {
@@ -293,96 +204,39 @@ namespace QuantConnect.DataProcessing
                 }
             }
 
-            throw new Exception($"Request failed with no more retries remaining (retry {_maxRetries}/{_maxRetries})");
+            throw new Exception($"QuiverWallStreetBetsDataDownloader.HttpRequester(): Request failed with no more retries remaining (retry {_maxRetries}/{_maxRetries})");
         }
 
         /// <summary>
-        /// Saves contents to disk, deleting existing zip files
+        /// Saves contents to disk
         /// </summary>
         /// <param name="destinationFolder">Final destination of the data</param>
-        /// <param name="name">file name</param>
+        /// <param name="name">File name</param>
         /// <param name="contents">Contents to write</param>
         private void SaveContentToFile(string destinationFolder, string name, IEnumerable<string> contents)
         {
-            name = name.ToLowerInvariant();
-            var finalPath = Path.Combine(destinationFolder, $"{name}.csv");
-            var finalFileExists = File.Exists(finalPath);
+            var lines = new HashSet<string>(contents).ToList();
 
-            var lines = new HashSet<string>(contents);
-            if (finalFileExists)
+            if (!destinationFolder.Contains("universe"))
             {
-                foreach (var line in File.ReadAllLines(finalPath))
-                {
-                    lines.Add(line);
-                }
+                lines = lines
+                    .OrderBy(x => DateTime.ParseExact(x.Split(',').First(), "yyyyMMdd", CultureInfo.InvariantCulture,
+                        DateTimeStyles.AdjustToUniversal))
+                    .ToList();
             }
 
-            var finalLines = destinationFolder.Contains("universe") ? 
-                lines.OrderBy(x => x.Split(',').First()).ToList() :
-                lines
-                .OrderBy(x => DateTime.ParseExact(x.Split(',').First(), "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal))
-                .ToList();
-
-            var tempPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.tmp");
-            File.WriteAllLines(tempPath, finalLines);
-            var tempFilePath = new FileInfo(tempPath);
-            tempFilePath.MoveTo(finalPath, true);
-        }
-
-        /// <summary>
-        /// Tries to normalize a potentially defunct ticker into a normal ticker.
-        /// </summary>
-        /// <param name="ticker">Ticker as received from Estimize</param>
-        /// <param name="nonDefunctTicker">Set as the non-defunct ticker</param>
-        /// <returns>true for success, false for failure</returns>
-        private static bool TryNormalizeDefunctTicker(string ticker, out string nonDefunctTicker)
-        {
-            // The "defunct" indicator can be in any capitalization/case
-            if (ticker.IndexOf("defunct", StringComparison.OrdinalIgnoreCase) > 0)
-            {
-                foreach (var delimChar in _defunctDelimiters)
-                {
-                    var length = ticker.IndexOf(delimChar);
-
-                    // Continue until we exhaust all delimiters
-                    if (length == -1)
-                    {
-                        continue;
-                    }
-
-                    nonDefunctTicker = ticker.Substring(0, length).Trim();
-                    return true;
-                }
-
-                nonDefunctTicker = string.Empty;
-                return false;
-            }
-
-            nonDefunctTicker = ticker;
-            return true;
-        }
-
-        private class Company
-        {
-            /// <summary>
-            /// The name of the company
-            /// </summary>
-            [JsonProperty(PropertyName = "Name")]
-            public string Name { get; set; }
-
-            /// <summary>
-            /// The ticker/symbol for the company
-            /// </summary>
-            [JsonProperty(PropertyName = "Ticker")]
-            public string Ticker { get; set; }
+            File.WriteAllLines(Path.Combine(destinationFolder, $"{name.ToLowerInvariant()}.csv"), lines);
         }
 
         /// <summary>
         /// Disposes of unmanaged resources
         /// </summary>
-        public void Dispose()
+        public void Dispose() => _indexGate?.Dispose();
+
+        private class RawQuiverWallStreetBets : QuiverWallStreetBets
         {
-            _indexGate?.Dispose();
+            [JsonProperty(PropertyName = "Ticker")]
+            public string Ticker { get; set; }
         }
     }
 }


### PR DESCRIPTION
Looping through every ticker places a big burden on Quiver API, which is why we changed to the new method of only calling the historical endpoint once.